### PR TITLE
Add reason for update in ArticleApiTest

### DIFF
--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -148,7 +148,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("reason for update");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
This pull request adds a new field `reason` to the `UpdateArticleRequest` in the `ArticleApiTest` class. This field allows specifying the reason for updating an article, enhancing the clarity and traceability of updates.