### PR TITLE
Fix shouldUpdateArticle test

### DIFF
--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -148,7 +148,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("test update reason");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
The test `shouldUpdateArticle` in `ArticleApiTest` was failing due to a missing `reason` field in the update request. The new update logic requires a non-empty `reason` field for the update to proceed.

Impacted methods:
1. `com.realworld.springmongo.api.ArticleController#createArticle`
2. `com.realworld.springmongo.article.ArticleFacade#createArticle`
3. `com.realworld.springmongo.article.ArticleFacade#updateArticle`

Changes:
- Added the `reason` field to the update request in the test.

Only test code was modified.