### PR TITLE
Fix missing `reason` field in update tests

### DIFF
--- a/src/apiTest/java/com/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/apiTest/java/com/com/realworld/springmongo/api/ArticleApiTest.java
@@ -134,7 +134,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("update reason");
 
         var updatedArticle = articleApi.updateArticle(article.getSlug(), updateArticleRequest, user.getToken());
         assert updatedArticle != null;
@@ -251,4 +252,3 @@ class ArticleApiTest {
         assert article2 != null;
         return new ArticlesAndUsers(List.of(article1, article2), List.of(user1, user2));
     }
-}

--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -148,7 +148,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("update reason");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
### Summary
This PR fixes the failed test `com.realworld.springmongo.api.ArticleApiTest#shouldUpdateArticle`. The root cause of the failure was the missing `reason` field in the `UpdateArticleRequest` object, which is now required due to a new non-blank validation.

### Changes
- Added `.setReason("update reason")` to the `UpdateArticleRequest` in the `shouldUpdateArticle` test.
- Updated both unit and integration API tests to include the `reason` field.

### Impacted Methods
The following methods were impacted and analyzed:
1. `com.realworld.springmongo.api.ArticleController#createArticle`
2. `com.realworld.springmongo.article.ArticleFacade#createArticle`
3. `com.realworld.springmongo.article.ArticleFacade#updateArticle`
4. `com.realworld.springmongo.article.dto.UpdateArticleRequest#getReason`
5. `com.realworld.springmongo.article.dto.UpdateArticleRequest#setReason`

### Notes
Only test files were modified to restore compatibility with the updated DTO.