### PR TITLE
Fix ArticleApiTest#shouldUpdateArticle

### DIFF
--- a/src/apiTest/java/com/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/apiTest/java/com/com/realworld/springmongo/api/ArticleApiTest.java
@@ -134,7 +134,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("update reason");
 
         var updatedArticle = articleApi.updateArticle(article.getSlug(), updateArticleRequest, user.getToken());
         assert updatedArticle != null;
@@ -251,4 +252,3 @@ class ArticleApiTest {
         assert article2 != null;
         return new ArticlesAndUsers(List.of(article1, article2), List.of(user1, user2));
     }
-}

--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -148,7 +148,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("update reason");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
This pull request addresses the failure in the test `com.realworld.springmongo.api.ArticleApiTest#shouldUpdateArticle`. The root cause was identified as a missing mandatory `reason` field in the `UpdateArticleRequest`. The impacted methods include:

1. `com.realworld.springmongo.api.ArticleController#createArticle`
2. `com.realworld.springmongo.article.ArticleFacade#createArticle`
3. `com.realworld.springmongo.article.ArticleFacade#updateArticle`
4. `com.realworld.springmongo.article.dto.UpdateArticleRequest#getReason`
5. `com.realworld.springmongo.article.dto.UpdateArticleRequest#setReason`

The fix ensures that the `reason` field is properly set in the test cases to align with the updated validation logic in the controller and facade layers. Only test code was modified.

Let me know if further adjustments are needed.