### PR TITLE
Add 'reason' field to UpdateArticleRequest

### DIFF
--- a/src/apiTest/java/com/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/apiTest/java/com/com/realworld/springmongo/api/ArticleApiTest.java
@@ -134,7 +134,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("update reason");
 
         var updatedArticle = articleApi.updateArticle(article.getSlug(), updateArticleRequest, user.getToken());
         assert updatedArticle != null;
@@ -251,4 +252,3 @@ class ArticleApiTest {
         assert article2 != null;
         return new ArticlesAndUsers(List.of(article1, article2), List.of(user1, user2));
     }
-}

--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -148,7 +148,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("update reason");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
This PR adds a new 'reason' field to the UpdateArticleRequest in the ArticleApiTest class.

Changes:
- Updated `src/apiTest/java/com/com/realworld/springmongo/api/ArticleApiTest.java` to include the 'reason' field.
- Updated `src/test/java/com/realworld/springmongo/api/ArticleApiTest.java` to include the 'reason' field.

This ensures that the update reason is captured during article updates.