### PR TITLE
Fix shouldUpdateArticle test for validation changes

### DIFF
--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -148,7 +148,9 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                // reason is required for update operations
+                .setReason("update reason");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
This PR fixes the `shouldUpdateArticle` test in `ArticleApiTest` to align with the recent validation changes in the `UpdateArticleRequest` class. Specifically, the `reason` field is now required, and the test has been updated to include a valid `reason` in the update payload.

### Root Cause
The test was failing because the `reason` field was missing in the payload, which violated the new `@NotBlankOrNull` validation rule introduced in `UpdateArticleRequest`.

### Impacted Methods
The following methods were impacted by the changes:
1. `com.realworld.springmongo.api.ArticleController#createArticle`
2. `com.realworld.springmongo.article.ArticleFacade#createArticle`
3. `com.realworld.springmongo.article.ArticleFacade#updateArticle`
4. `com.realworld.springmongo.article.dto.UpdateArticleRequest#getReason`
5. `com.realworld.springmongo.article.dto.UpdateArticleRequest#setReason`

### Notes
Only test code was modified to fix the issue. No changes were made to the application logic.