### PR TITLE
Add reason field to UpdateArticleRequest in ArticleApiTest

### DIFF
--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -148,7 +148,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("reason for update");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
This PR adds a new field `reason` to the `UpdateArticleRequest` in the `ArticleApiTest` class. This field is intended to provide a reason for the update operation, enhancing the clarity and traceability of updates.