### PR TITLE
Fix shouldUpdateArticle test

### DIFF
--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -148,7 +148,9 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                // reason is required for update operations
+                .setReason("update reason");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
### Summary
This PR fixes the `shouldUpdateArticle` test in `ArticleApiTest`. The root cause of the failure was a missing `reason` field in the `UpdateArticleRequest`. The `updateArticle` method in the `ArticleFacade` enforces a non-null, non-empty `reason` for edits, which caused the test to fail.

### Changes
- Added a valid `reason` to the `UpdateArticleRequest` in the `shouldUpdateArticle` test.

### Impacted Methods
- `com.realworld.springmongo.api.ArticleController#createArticle`
- `com.realworld.springmongo.article.ArticleFacade#createArticle`
- `com.realworld.springmongo.article.ArticleFacade#updateArticle`
- `com.realworld.springmongo.article.dto.UpdateArticleRequest#getReason`
- `com.realworld.springmongo.article.dto.UpdateArticleRequest#setReason`

### Notes
Only test code was modified to address the issue.