### PR TITLE
Fix update-article test

### DIFF
--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -148,7 +148,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("update reason");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
### Summary
This PR fixes the failed test `com.realworld.springmongo.api.ArticleApiTest#shouldUpdateArticle`. The root cause was a missing "reason" field in the test setup, which is now required due to validation changes in `UpdateArticleRequest`.

### Impacted Methods
1. `com.realworld.springmongo.api.ArticleController#createArticle`
2. `com.realworld.springmongo.article.ArticleFacade#createArticle`
3. `com.realworld.springmongo.article.ArticleFacade#updateArticle`
4. `com.realworld.springmongo.article.dto.UpdateArticleRequest#getReason`
5. `com.realworld.springmongo.article.dto.UpdateArticleRequest#setReason`

### Changes
Only test code was modified:
- Updated `shouldUpdateArticle()` in `ArticleApiTest` to include a non-empty "reason" field in the request builder.

Let me know if further adjustments are needed.