### PR TITLE
test: add reason to UpdateArticleRequest in shouldUpdateArticle test

### DIFF
--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -148,7 +148,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("update reason");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
Root cause:
- A new required field "reason" was added to UpdateArticleRequest in production code. The updateArticle flow validates that reason is provided. The test shouldUpdateArticle did not include this new field, causing the assertion to fail.

Fix:
- Updated the test com.realworld.springmongo.api.ArticleApiTest#shouldUpdateArticle to setReason("update reason") on the UpdateArticleRequest used in the test.

Impacted methods:
- com.realworld.springmongo.article.ArticleFacade.updateArticle(UpdateArticleRequest, User, Article)
- com.realworld.springmongo.article.dto.UpdateArticleRequest.getReason()
- com.realworld.springmongo.article.dto.UpdateArticleRequest.setReason(String)

Note: Only test code was modified.
