### PR TITLE
tests: set reason on UpdateArticleRequest in ArticleApiTest to match new required field

### DIFF
--- a/src/apiTest/java/com/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/apiTest/java/com/com/realworld/springmongo/api/ArticleApiTest.java
@@ -134,7 +134,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("update reason");
 
         var updatedArticle = articleApi.updateArticle(article.getSlug(), updateArticleRequest, user.getToken());
         assert updatedArticle != null;
@@ -251,4 +252,3 @@ class ArticleApiTest {
         assert article2 != null;
         return new ArticlesAndUsers(List.of(article1, article2), List.of(user1, user2));
     }
-}

--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -148,7 +148,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("update reason");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
This PR fixes failing tests caused by the addition of a required `reason` field in UpdateArticleRequest and related update flow.

Summary of root cause:
- Production code introduced a new `reason` property on UpdateArticleRequest (and ArticleFacade.updateArticle now expects it to be set).
- Existing tests did not include this field when constructing update requests, causing assertions to fail.

What I changed:
- Updated only test files to set the new `reason` field:
  - src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
  - src/apiTest/java/com/com/realworld/springmongo/api/ArticleApiTest.java

Impacted methods referenced:
- com.realworld.springmongo.article.ArticleFacade.updateArticle
- com.realworld.springmongo.article.dto.UpdateArticleRequest.getReason / setReason

Note: Only test code was modified to align tests with updated behavior. No production code was changed.
