### PR TITLE
test: provide reason in UpdateArticleRequest for shouldUpdateArticle

### DIFF
--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ArticleApiTest {
+    // Test update now requires a reason field introduced in UpdateArticleRequest
 
     @Autowired
     WebTestClient client;
@@ -148,7 +149,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("tests: updating article");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
The UpdateArticleRequest DTO gained a required 'reason' field which caused the shouldUpdateArticle test to fail when the reason was not provided. This PR updates the test to set a reason ("tests: updating article") when creating the UpdateArticleRequest so the request passes validation.

Impacted methods: com.realworld.springmongo.article.ArticleFacade.updateArticle, com.realworld.springmongo.article.dto.UpdateArticleRequest.getReason/setReason

Only test code was modified.