### PR TITLE
test: include reason in update article request

### DIFF
--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -148,7 +148,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("update reason");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
Root cause:
The UpdateArticleRequest DTO now includes a reason field that must be populated when updating an article. The ArticleFacade.updateArticle and UpdateArticleRequest getters/setters were changed in the commit which impacted the test. The shouldUpdateArticle test did not set the reason field, causing assertion failures.

Impacted methods:
- com.realworld.springmongo.article.ArticleFacade.updateArticle
- com.realworld.springmongo.article.dto.UpdateArticleRequest.getReason
- com.realworld.springmongo.article.dto.UpdateArticleRequest.setReason

What I changed:
- Only test code updated: src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
- Added setting of reason in the updateArticle request in the failing test.

Notes:
- No production code was modified.
