### PR TITLE
test: set reason on UpdateArticleRequest in shouldUpdateArticle test

### DIFF
--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -149,6 +149,8 @@ class ArticleApiTest {
                 .setBody("new body")
                 .setDescription("new description")
                 .setTitle("new title");
+        // reason field was added and is required by the API for updates
+        updateArticleRequest.setReason("update reason");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
Summary

The failing test com.realworld.springmongo.api.ArticleApiTest#shouldUpdateArticle was failing because UpdateArticleRequest now includes a required "reason" field. The test did not set this field, causing assertions to fail.

Root cause

- The production changes introduced a new required field reason on UpdateArticleRequest and the ArticleFacade.updateArticle uses it.
- Impacted methods: com.realworld.springmongo.article.ArticleFacade.updateArticle, UpdateArticleRequest.getReason, UpdateArticleRequest.setReason

Fix

- Only test code was changed: set the reason field in the test to a sample value so the update request mirrors the required payload.

No production code was modified.

This PR updates: src/test/java/com/realworld/springmongo/api/ArticleApiTest.java

closes #0