### PR TITLE
test: include reason in UpdateArticleRequest in ArticleApiTest#shouldUpdateArticle

### DIFF
--- a/src/apiTest/java/com/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/apiTest/java/com/com/realworld/springmongo/api/ArticleApiTest.java
@@ -134,7 +134,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("updated for tests");
 
         var updatedArticle = articleApi.updateArticle(article.getSlug(), updateArticleRequest, user.getToken());
         assert updatedArticle != null;
@@ -251,4 +252,3 @@ class ArticleApiTest {
         assert article2 != null;
         return new ArticlesAndUsers(List.of(article1, article2), List.of(user1, user2));
     }
-}

--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -148,7 +148,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("updated for tests");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
Root cause:
- Tests started failing because UpdateArticleRequest gained a new required/used field `reason` which the test did not set. Impacted methods: ArticleFacade.updateArticle, UpdateArticleRequest.getReason, UpdateArticleRequest.setReason.

Fix:
- Only test code changed: added .setReason("updated for tests") to the UpdateArticleRequest instantiation in ArticleApiTest#shouldUpdateArticle so the request matches the current expected shape.

This PR modifies only test files.
