### PR TITLE
test: include required reason in UpdateArticleRequest for shouldUpdateArticle



### DIFF
--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -145,10 +145,14 @@ class ArticleApiTest {
         var article = articleApi.createArticle(ArticleSamples.sampleCreateArticleRequest(), user.getToken());
         assert article != null;
         var slug = article.getSlug();
+        // The UpdateArticleRequest in the application now requires a non-empty "reason" field
+        // (validation added in a recent change). Include a reason here to satisfy the
+        // new validation rule so the test updates the article successfully.
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("update for test");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
Root cause: An UpdateArticleRequest gained a new required field `reason` and validation was added in ArticleFacade.updateArticle. The existing test did not provide this field, causing validation to fail and the test to assert incorrectly.

Impacted methods (from impact analysis):
- com.realworld.springmongo.article.ArticleFacade.updateArticle(UpdateArticleRequest, User, Article)
- com.realworld.springmongo.article.dto.UpdateArticleRequest.getReason()
- com.realworld.springmongo.article.dto.UpdateArticleRequest.setReason(String)

Fix: Updated only test code to include a non-empty reason ("update for test") in the UpdateArticleRequest used by the failing test. No production code changed.
