### PR TITLE
tests: include required reason field for update article requests

### DIFF
--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -91,7 +91,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setTitle("smoke-article-updated")
                 .setDescription("updated description")
-                .setBody("updated body");
+                .setBody("updated body")
+                .setReason("test update");
         var updatedArticle = articleApi.updateArticle(createdArticle.getSlug(), updateArticleRequest, token);
         assertThat(updatedArticle).isNotNull();
         var newSlug = updatedArticle.getSlug();
@@ -210,7 +211,7 @@ class ArticleApiTest {
                 .setBody("new body")
                 .setDescription("new description")
                 .setTitle("new title");
-
+        updateArticleRequest.setReason("test update");
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;
 

--- a/update-test-reason.patch
+++ b/update-test-reason.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tests Fixer <devnull@example.com>
+Date: Fri, 13 Feb 2026 00:00:00 +0000
+Subject: [PATCH] tests: include required reason field for update article requests
+
+---
+ src/test/java/com/realworld/springmongo/api/ArticleApiTest.java | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+index 0000000..1111111 100644
+--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+@@
+-        var updateArticleRequest = new UpdateArticleRequest()
+-                .setTitle("smoke-article-updated")
+-                .setDescription("updated description")
+-                .setBody("updated body");
++        var updateArticleRequest = new UpdateArticleRequest()
++                .setTitle("smoke-article-updated")
++                .setDescription("updated description")
++                .setBody("updated body")
++                .setReason("test update");
+@@
+-        var updateArticleRequest = new UpdateArticleRequest()
+-                .setBody("new body")
+-                .setDescription("new description")
+-                .setTitle("new title");
+-
++        var updateArticleRequest = new UpdateArticleRequest()
++                .setBody("new body")
++                .setDescription("new description")
++                .setTitle("new title");
++        updateArticleRequest.setReason("test update");


### PR DESCRIPTION
Summary:

A recent change introduced a required "reason" field on UpdateArticleRequest and ArticleFacade.updateArticle now validates that reason is present. Existing tests that perform article updates did not set this field, causing test failures. This PR updates tests to include a non-empty reason when creating UpdateArticleRequest instances so they satisfy the new validation.

Impacted methods (from analysis):
- com.realworld.springmongo.article.ArticleFacade#updateArticle
- com.realworld.springmongo.article.dto.UpdateArticleRequest#getReason / setReason

Note: Only test code was modified to adapt to the new validation. No production code changes were made.
