### PR TITLE
test: adapt UpdateArticleRequest usage to include reason field in ArticleApiTest

### DIFF
--- a/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
+++ b/src/test/java/com/realworld/springmongo/api/ArticleApiTest.java
@@ -91,7 +91,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setTitle("smoke-article-updated")
                 .setDescription("updated description")
-                .setBody("updated body");
+                .setBody("updated body")
+                .setReason("update for smoke test");
         var updatedArticle = articleApi.updateArticle(createdArticle.getSlug(), updateArticleRequest, token);
         assertThat(updatedArticle).isNotNull();
         var newSlug = updatedArticle.getSlug();
@@ -209,7 +210,8 @@ class ArticleApiTest {
         var updateArticleRequest = new UpdateArticleRequest()
                 .setBody("new body")
                 .setDescription("new description")
-                .setTitle("new title");
+                .setTitle("new title")
+                .setReason("update for test");
 
         var updatedArticle = articleApi.updateArticle(slug, updateArticleRequest, user.getToken());
         assert updatedArticle != null;


### PR DESCRIPTION
The failing test shouldUpdateArticle was updated to include the new `reason` field in UpdateArticleRequest payloads used by ArticleApiTest.

Root cause: ArticleFacade.updateArticle signature/behavior was changed to expect a `reason` field in UpdateArticleRequest (impacted method: com.realworld.springmongo.article.ArticleFacade#updateArticle). Tests were not updated accordingly, causing assertion failures. Only test code updated to reflect new request shape.

Changes:
- src/test/java/com/realworld/springmongo/api/ArticleApiTest.java: set `reason` on UpdateArticleRequest instances.

This change only touches test files.
