### PR TITLE
Fix: handle 204 No Content in UserApiSupport.updateUser to avoid NPE in tests



### DIFF
--- a/src/test/java/helpers/user/UserApiSupport.java
+++ b/src/test/java/helpers/user/UserApiSupport.java
@@ -18,14 +18,16 @@ public class UserApiSupport {
     }
 
     public UserView updateUser(String token, UpdateUserRequest updateUserRequest) {
-        var result = client.put()
+        // The API returns 204 No Content for update requests. After updating we need to
+        // fetch the current user to obtain the updated representation.
+        client.put()
                 .uri("/api/user")
                 .header(HttpHeaders.AUTHORIZATION, TokenHelper.formatToken(token))
                 .bodyValue(new UpdateUserRequestWrapper(updateUserRequest))
                 .exchange()
-                .expectBody(UserViewWrapper.class)
-                .returnResult();
-        return result.getResponseBody().getContent();
+                .expectStatus().isNoContent();
+
+        return currentUser(token);
     }
 
     public UserView currentUser(String token) {


### PR DESCRIPTION
Root cause:

A NullPointerException occurred in helpers.user.UserApiSupport.updateUser during com.realworld.springmongo.api.UserApiTest#shouldUpdateUser. The updateUser helper was attempting to parse a response body from the PUT /api/user call; however the API returns 204 No Content on successful updates, leading to a null response body and the NPE.

What I changed:
- Updated src/test/java/helpers/user/UserApiSupport.java to treat the PUT /api/user response as 204 No Content. After performing the update request, the helper now calls the existing currentUser(token) method to fetch and return the updated user representation.

Impacted methods:
- helpers.user.UserApiSupport.updateUser (test helper)

Notes:
- Only test code was modified. No production code changes were made.

