### PR TITLE
Test: defensive null check in UserApiSupport.updateUser to avoid NPE

### DIFF
--- a/src/test/java/helpers/user/UserApiSupport.java
+++ b/src/test/java/helpers/user/UserApiSupport.java
@@ -25,7 +25,13 @@ public class UserApiSupport {
                 .exchange()
                 .expectBody(UserViewWrapper.class)
                 .returnResult();
-        return result.getResponseBody().getContent();
+        var wrapper = result.getResponseBody();
+        if (wrapper == null) {
+            var content = result.getResponseBodyContent();
+            var status = result.getStatus();
+            throw new AssertionError("Expected response body for updateUser but got none. Status: " + status + ", body: " + (content == null ? "null" : new String(content)));
+        }
+        return wrapper.getContent();
     }
 
     public UserView currentUser(String token) {


### PR DESCRIPTION
Root cause: UserApiSupport.updateUser assumed response body was non-null, which caused NPE when response body was missing during test flow. Modified affected test helper to check for null response wrapper and throw an informative AssertionError including status and raw body.

Impacted methods: helpers.user.UserApiSupport.updateUser (test helper). Only test code changed.