### PR TITLE
Fix test helper: handle 204 No Content for updateUser to avoid NPE

### DIFF
--- a/src/test/java/helpers/user/UserApiSupport.java
+++ b/src/test/java/helpers/user/UserApiSupport.java
@@ -18,14 +18,16 @@ public class UserApiSupport {
     }
 
     public UserView updateUser(String token, UpdateUserRequest updateUserRequest) {
-        var result = client.put()
+        // Controller now returns 204 No Content for update operation.
+        // Perform the update and then fetch the current user to obtain the updated UserView.
+        client.put()
                 .uri("/api/user")
                 .header(HttpHeaders.AUTHORIZATION, TokenHelper.formatToken(token))
                 .bodyValue(new UpdateUserRequestWrapper(updateUserRequest))
                 .exchange()
-                .expectBody(UserViewWrapper.class)
-                .returnResult();
-        return result.getResponseBody().getContent();
+                .expectStatus().isNoContent();
+
+        return currentUser(token);
     }
 
     public UserView currentUser(String token) {


### PR DESCRIPTION
Root cause:
The User update endpoint was changed to return 204 No Content. The test helper helpers.user.UserApiSupport.updateUser still expected a response body and called getResponseBody().getContent(), which became null and caused a NullPointerException at helpers.user.UserApiSupport.updateUser:28.

What I changed:
- Updated src/test/java/helpers/user/UserApiSupport.java to expect a 204 No Content response from the update endpoint and then fetch the current user via currentUser(token) to obtain the updated UserView.

Impacted methods (from impact analysis):
- com.realworld.springmongo.api.UserController:updateUser
- com.realworld.springmongo.user.UserUpdater:updateUser and related lambdas

Notes:
- Only test code was modified (test helper). No production code was changed.
- The change avoids dereferencing a null response body and preserves the test's intent by returning the updated UserView.
