### PR TITLE
Fix: handle 204 No Content in UserApiSupport.updateUser to avoid NPE in tests

### DIFF
--- a/src/test/java/helpers/user/UserApiSupport.java
+++ b/src/test/java/helpers/user/UserApiSupport.java
@@ -18,14 +18,15 @@ public class UserApiSupport {
     }
 
     public UserView updateUser(String token, UpdateUserRequest updateUserRequest) {
-        var result = client.put()
+        // Controller now returns 204 No Content. Perform the update then fetch current user to obtain updated view.
+        client.put()
                 .uri("/api/user")
                 .header(HttpHeaders.AUTHORIZATION, TokenHelper.formatToken(token))
                 .bodyValue(new UpdateUserRequestWrapper(updateUserRequest))
                 .exchange()
-                .expectBody(UserViewWrapper.class)
-                .returnResult();
-        return result.getResponseBody().getContent();
+                .expectStatus().isNoContent();
+
+        return currentUser(token);
     }
 
     public UserView currentUser(String token) {


### PR DESCRIPTION
Root cause:
The production change for UserController.updateUser switched to returning 204 No Content (Mono<Void>) instead of returning the updated user body. The test helper helpers.user.UserApiSupport.updateUser still attempted to read a response body, causing a NullPointerException in com.realworld.springmongo.api.ArticleApiTest#shouldRunFullUserArticleFlow.

What I changed:
- Updated src/test/java/helpers/user/UserApiSupport.java to accept the 204 No Content response and then fetch the current user via existing currentUser(token) helper to obtain the updated UserView. This preserves test expectations without modifying production code.

Impacted methods (from impact analysis):
- com.realworld.springmongo.api.UserController.updateUser
- com.realworld.springmongo.user.UserUpdater.updateUser and related lambdas

Notes:
- Only test code was changed (test helper). No production code changes were made.
