### PR TITLE
tests: handle 204 No Content in user update API (fix failing ArticleApiTest)

### DIFF
--- a/src/test/java/helpers/user/UserApiSupport.java
+++ b/src/test/java/helpers/user/UserApiSupport.java
@@ -18,14 +18,15 @@ public class UserApiSupport {
     }
 
     public UserView updateUser(String token, UpdateUserRequest updateUserRequest) {
-        var result = client.put()
+        var responseSpec = client.put()
                 .uri("/api/user")
                 .header(HttpHeaders.AUTHORIZATION, TokenHelper.formatToken(token))
                 .bodyValue(new UpdateUserRequestWrapper(updateUserRequest))
-                .exchange()
-                .expectBody(UserViewWrapper.class)
-                .returnResult();
-        return result.getResponseBody().getContent();
+                .exchange();
+
+        // Controller now returns 204 No Content on update. Fetch current user to obtain updated data.
+        responseSpec.expectStatus().isNoContent();
+        return currentUser(token);
     }
 
     public UserView currentUser(String token) {


### PR DESCRIPTION
Root cause:
The user update endpoint behavior was changed to return 204 No Content. Test helper UserApiSupport.updateUser expected a response body and attempted to read it, causing a NullPointerException. Impacted methods (from Drill4J): com.realworld.springmongo.api.UserController.updateUser, com.realworld.springmongo.user.UserUpdater.updateUser and related lambdas.

What I changed:
Only test code was modified. The helper now treats a 204 response as success and fetches the current user to obtain updated data, avoiding the NPE.

Impacted methods reference: com.realworld.springmongo.api.UserController.updateUser, com.realworld.springmongo.user.UserUpdater.updateUser, and related lambdas.

Note: Only test files were changed.
